### PR TITLE
Fix KinD setup and running guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
-# dracon-community-pipelines
-A collection of community contributed Dracon Pipelines look here for inspiration or solutions
+## Getting Started with Dracon on [KinD](https://kind.sigs.k8s.io/)
 
-## Quickstart
+KinD is is a tool for running local Kubernetes clusters using Docker container “nodes”.
 
-### Prerequisites
+## Quick Guide
 
-- Access to a Kubernetes cluster w/ Tekton Pipelines installed. See below for a local version.
-
-#### Local Kubernetes w/ Tekton Pipelines via [KinD](https://kind.sigs.k8s.io/)
 
 1. Create KinD cluster named `dracon-demo`. For more info, see [official documentation](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster):
 
@@ -26,12 +22,19 @@ A collection of community contributed Dracon Pipelines look here for inspiration
     ```bash
     $ curl -sL https://raw.githubusercontent.com/tektoncd/dashboard/main/scripts/release-installer | \
         bash -s -- install latest --read-write
-    # Use `kubectl proxy` so you can access Kubernetes services on your local machine.
-    $ kubectl proxy
-    # Tekton Dashboard is now available at: http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/#/about
+    # Use `kubectl port-forward ...` so you can access Kubernetes services on your local machine.
+    $ kubectl -n tekton-pipelines port-forward svc/tekton-dashboard 9097:9097
+    # Tekton Dashboard is now available at: http://localhost:9097
     ```
 
-4. **Optional**: Install ECK and create an Elasticsearch + Kibana Dashboards. For more info, see [official documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html).
+4. Create a Postgres DB to use as the Dracon deduplication DB:
+
+    ```bash
+    # Create a StatefulSet and Service for the Dracon deduplication DB. In production, we recommend using a production-ready or managed Postgres deployment.
+    $ kubectl apply -f https://github.com/ocurity/dracon-community-pipelines/blob/main/resources/deduplication-enricher-db.yaml
+    ```
+
+5. Install ECK and create an Elasticsearch + Kibana Dashboards. For more info, see [official documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html).
 
     ```bash
     # Create ECK CRDs.
@@ -39,43 +42,91 @@ A collection of community contributed Dracon Pipelines look here for inspiration
     # Apply ECK operator resources.
     $ kubectl apply -f https://download.elastic.co/downloads/eck/2.6.1/operator.yaml
     # Create Elasticsearch.
-    $ cat <<EOF | kubectl apply -f -
-    apiVersion: elasticsearch.k8s.elastic.co/v1
-    kind: Elasticsearch
-    metadata:
-    name: quickstart
-    spec:
-    version: 8.6.1
-    nodeSets:
-    - name: default
-        count: 1
-        config:
-        node.store.allow_mmap: false
-    EOF
+    $ kubectl apply -f https://github.com/ocurity/dracon-community-pipelines/blob/main/resources/eck-elasticsearch.yaml
     # Create Kibana.
-    $ cat <<EOF | kubectl apply -f -
-    apiVersion: kibana.k8s.elastic.co/v1
-    kind: Kibana
+    $ kubectl apply -f https://github.com/ocurity/dracon-community-pipelines/blob/main/resources/eck-kibana.yaml
+    # Use `kubectl port-forward ...` to access the Kibana UI:
+    $ kubectl port-forward svc/quickstart-kb-http 5601:5601
+    # You can obtain the password by examining the `quickstart-es-elastic-user` secret:
+    # The username is `elastic`.
+    $ kubectl get secret quickstart-es-elastic-user \
+        -o=jsonpath='{.data.elastic}' \
+        | base64 -d - \
+        | xargs echo "$1"
+    ```
+
+### Composing a Pipeline
+
+We use [Kustomize Components](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/components.md) to create composable Dracon Pipelines.
+
+1. Create the following simple Dracon Pipeline in your directory:
+
+    ```yaml
+    ---
+    # ./kustomization.yaml
+    apiVersion: kustomize.config.k8s.io/v1beta1
+    kind: Kustomization
+
+    nameSuffix: -github-com-kubernetes-kubernetes
+    namespace: default
+
+    resources:
+    - https://github.com/ocurity/dracon//components/base/
+
+    components:
+    - https://github.com/ocurity/dracon//components/sources/git/
+    - https://github.com/ocurity/dracon//components/producers/aggregator/
+    - https://github.com/ocurity/dracon//components/producers/golang-gosec/
+    - https://github.com/ocurity/dracon//components/producers/golang-nancy/
+    - https://github.com/ocurity/dracon//components/enrichers/aggregator/
+    - https://github.com/ocurity/dracon//components/enrichers/deduplication/
+    - https://github.com/ocurity/dracon//components/consumers/elasticsearch/
+    ```
+
+2. Run the following to create the Tekton Pipeline, Task, etc. resources on your cluster:
+
+    ```bash
+    $ kustomize build | kubectl apply -f -
+    # Note: you can just run the below to see the generated Tekton Pipeline resources
+    # $ kustomize build
+    ```
+
+3. Create the following Tekton PipelineRun file:
+
+    ```yaml
+    ---
+    # pipelinerun.yaml
+    # Run `kubectl create ...` with this file.
+    apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
     metadata:
-    name: quickstart
+      generateName: dracon-github-com-kubernetes-kubernetes-
     spec:
-    version: 8.6.1
-    count: 1
-    elasticsearchRef:
-        name: quickstart
-    EOF
+      pipelineRef:
+        name: dracon-github-com-kubernetes-kubernetes
+      params:
+        - name: repository_url
+          value: https://github.com/kubernetes/kubernetes.git
+        - name: consumer-elasticsearch-url
+          value: http://quickstart-es-http.default.svc:9200
+      workspaces:
+        - name: source-code-ws
+          subPath: source-code
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
     ```
 
-### Running a Community Pipeline
-
-1. Apply the Pipeline resources output via Kustomize to your cluster:
+4. Create the PipelineRun resource:
 
     ```bash
-    $ kustomize build pipelines/github.com/kubernetes/kubernetes/ | kubectl apply -f -
+    $ kubectl create -f pipelinerun.yaml
     ```
 
-2. Create a PipelineRun
+5. Observe the PipelineRun at http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/#/about
 
-    ```bash
-    $ kubectl create -f pipelines/github.com/kubernetes/kubernetes/pipelinerun.yaml
-    ```
+6. Once the PipelineRun has finished, you can view the output in Kibana at http://localhost:5601.

--- a/pipelines/github.com/kubernetes/kubernetes/pipelinerun.yaml
+++ b/pipelines/github.com/kubernetes/kubernetes/pipelinerun.yaml
@@ -3,23 +3,21 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   generateName: dracon-github-com-kubernetes-kubernetes-
-  namespace: default
 spec:
-  serviceAccountName: dracon
   pipelineRef:
     name: dracon-github-com-kubernetes-kubernetes
   params:
-  - name: repository_url
-    value: https://github.com/kubernetes/kubernetes.git
-  - name: consumer-elasticsearch-url
-    value: http://quickstart-es-http:9200
+    - name: repository_url
+      value: https://github.com/kubernetes/kubernetes.git
+    - name: consumer-elasticsearch-url
+      value: http://quickstart-es-http.default.svc:9200
   workspaces:
-  - name: source-code-ws
-    subPath: source-code
-    volumeClaimTemplate:
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
+    - name: source-code-ws
+      subPath: source-code
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/resources/deduplication-enricher-db.yaml
+++ b/resources/deduplication-enricher-db.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dracon-enrichment-db
+  labels:
+    app: dracon-enrichment-db
+    project: dracon
+spec:
+  revisionHistoryLimit: 3
+  serviceName: dracon-enrichment-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dracon-enrichment-db
+      project: dracon
+  template:
+    metadata:
+      labels:
+        app: dracon-enrichment-db
+        project: dracon
+    spec:
+      securityContext:
+        fsGroup: 70
+      containers:
+        - name: dracon-enrichment-db
+          image: postgres:alpine
+          env:
+            - name: POSTGRES_USER
+              value: dracon
+            - name: POSTGRES_PASSWORD
+              value: dracon
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 0.5
+            limits:
+              memory: 5Gi
+              cpu: 1
+          ports:
+            - containerPort: 5432
+          securityContext:
+            runAsUser: 70
+            runAsGroup: 70
+          volumeMounts:
+            - mountPath: /var/lib/postgresql
+              name: dracon-postgres
+              subPath: postgres-db
+  volumeClaimTemplates:
+    - metadata:
+        name: dracon-postgres
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dracon-enrichment-db
+  labels:
+    project: dracon
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: dracon-enrichment-db

--- a/resources/eck-elasticsearch.yaml
+++ b/resources/eck-elasticsearch.yaml
@@ -1,0 +1,21 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: quickstart
+spec:
+  version: 8.3.2
+  image: docker.elastic.co/elasticsearch/elasticsearch:8.3.2
+  http:
+    tls:
+      selfSignedCertificate:
+        disabled: true
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.store.allow_mmap: false
+      xpack.security.authc:
+        anonymous:
+          username: anonymous
+          roles: superuser
+          authz_exception: false

--- a/resources/eck-kibana.yaml
+++ b/resources/eck-kibana.yaml
@@ -1,0 +1,33 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: quickstart
+spec:
+  version: 8.3.2
+  image: docker.elastic.co/kibana/kibana:8.3.2
+  count: 1
+  elasticsearchRef:
+    name: quickstart
+  # config:
+  #   xpack.security.enabled: false
+  http:
+    tls:
+      selfSignedCertificate:
+        disabled: true
+  podTemplate:
+    spec:
+      containers:
+        - name: kibana
+          resources:
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 5601
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5


### PR DESCRIPTION
This PR fixes the Dracon setup guidance in KinD, most notably the deployment of a Postgres DB.